### PR TITLE
Bugfix/hero/about text/images

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,7 +6,7 @@ export default function About() {
   return (
     <>
       {/* Version 2: Background image with text on top */}
-      <section className="relative min-h-[70vh] flex items-center">
+      <article className="relative min-h-[70vh] flex items-center">
         {/* Background Image */}
         <Image
           src="https://images.unsplash.com/photo-1698858212917-9dbd472abecb?w=1800&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTF8fGZyZWUlMjBpbWFnZXMlMjBzdG9ja2hvbG18ZW58MHx8MHx8fDA%3D"
@@ -20,18 +20,18 @@ export default function About() {
         <div className="absolute inset-0 bg-linear-to-t from-black/80 to-transparent" />
 
         {/* Text content */}
-        <div className="relative z-9 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-16 w-full">
+        <section className="relative z-9 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-16 w-full">
           <div className="max-w-2xl space-y-6 text-shadow-md">
             <p className="text-sm text-white uppercase tracking-widest">
               Our Story
             </p>
 
-            <h2 className="font-serif text-4xl sm:text-5xl text-white text-pretty">
-              Everything you need, all in one place
-            </h2>
+            <h1 className="font-serif text-4xl sm:text-5xl text-white text-pretty">
+              A store built around you
+            </h1>
 
             <p className="text-white leading-relaxed">
-              At DreamShop, we believe shopping should be simple and enjoyable.
+              At DreamShop, we believe shopping should be simple and enjoyable - everything you need, all in one place.
               From electronics and furniture to beauty and fashion, our curated
               selection brings together the best products across every category.
             </p>
@@ -49,8 +49,8 @@ export default function About() {
               <ArrowRight className="h-4 w-4" />
             </Link>
           </div>
-        </div>
-      </section>
+        </section>
+      </article>
     </>
   );
 }

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,11 +6,11 @@ export default function About() {
   return (
     <>
       {/* Version 2: Background image with text on top */}
-      <section className="relative min-h-[85vh] flex items-center">
+      <section className="relative min-h-[70vh] flex items-center">
         {/* Background Image */}
         <Image
           src="https://images.unsplash.com/photo-1698858212917-9dbd472abecb?w=1800&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTF8fGZyZWUlMjBpbWFnZXMlMjBzdG9ja2hvbG18ZW58MHx8MHx8fDA%3D"
-          alt="Our story"
+          alt="Our story - Image of Stockholm City, Gamla Stan featuring a prominent church"
           fill
           className="object-cover"
           priority

--- a/components/ui/hero.tsx
+++ b/components/ui/hero.tsx
@@ -21,8 +21,8 @@ export default function Hero() {
 
       {/* Text section */}
       <section className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20 lg:py-32 w-full">
-        <div className="max-w-lg">
-          <span className="text-sm font-semibold text-blue-600 uppercase tracking-wide">
+        <div className="max-w-lg text-shadow-xs">
+          <span className="text-sm font-semibold text-blue-600 uppercase tracking-wide ps-1">
             Spring & Summer 2026
           </span>
 
@@ -30,7 +30,7 @@ export default function Hero() {
             Discover your personal style
           </h1>
 
-          <p className="mt-6 text-lg text-black/90 max-w-md leading-relaxed">
+          <p className="mt-6 text-lg text-black max-w-md leading-relaxed">
             Timeless fashion and accessories — carefully curated for those who
             appreciate quality and design.
           </p>

--- a/components/ui/hero.tsx
+++ b/components/ui/hero.tsx
@@ -8,7 +8,7 @@ export default function Hero() {
       <div className="absolute inset-0">
         <Image
           src={
-            "https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=1920&q=80"
+            "https://images.unsplash.com/photo-1472851294608-062f824d29cc?w=1920&q=80"
           }
           alt="Dream Webshop hero image"
           fill
@@ -23,16 +23,15 @@ export default function Hero() {
       <section className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20 lg:py-32 w-full">
         <div className="max-w-lg text-shadow-xs">
           <span className="text-sm font-semibold text-blue-600 uppercase tracking-wide ps-1">
-            Spring & Summer 2026
+            New arrivals
           </span>
 
           <h1 className="font-serif text-4xl sm:text-5xl lg:text-6xl font-medium tracking-tight text-balance leading-tight">
-            Discover your personal style
+            Everything you need, all in one place
           </h1>
 
-          <p className="mt-6 text-lg text-black max-w-md leading-relaxed">
-            Timeless fashion and accessories — carefully curated for those who
-            appreciate quality and design.
+          <p className="mt-6 text-lg text-black max-w-md leading-relaxed text-balance">
+            From electronics to furniture to beauty and fashion - curated products from trusted brands, all in one place.
           </p>
 
           <Link


### PR DESCRIPTION
We got a slogan now - "Everything you need, all in one place"

Fix about page banner to be the same height as hero banner, it was bigger before

Fix hero text style, added a faint text shadow and adjusted removed opacity on paragraph

Fix new image for hero banner thats more neutral, new text on hero thats less fashion focused with our new slogan, adjusted text on about page as well in a similar vein
